### PR TITLE
Feat/#6-매치 도메인 구현 및 동시성 제어

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    // --- migration ---
+    // --- flyway ---
     implementation 'org.flywaydb:flyway-database-postgresql'
 
     // --- json web token ---
@@ -55,6 +55,13 @@ dependencies {
 
     // aws
     implementation 'software.amazon.awssdk:s3:2.29.50'
+
+    // OpenFeign QueryDSL - JPA
+    implementation "io.github.openfeign.querydsl:querydsl-jpa:7.0"
+    annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:7.0:jpa"
+
+    // Redisson
+    implementation "org.redisson:redisson:3.52.0"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/chaean/teamchatsa/domain/match/controller/MatchController.java
+++ b/src/main/java/com/chaean/teamchatsa/domain/match/controller/MatchController.java
@@ -1,0 +1,105 @@
+package com.chaean.teamchatsa.domain.match.controller;
+
+import com.chaean.teamchatsa.domain.match.dto.request.MatchApplicationReq;
+import com.chaean.teamchatsa.domain.match.dto.request.MatchPostCreateReq;
+import com.chaean.teamchatsa.domain.match.dto.response.MatchPostDetailRes;
+import com.chaean.teamchatsa.domain.match.dto.response.MatchPostListRes;
+import com.chaean.teamchatsa.domain.match.service.MatchService;
+import com.chaean.teamchatsa.domain.team.model.TeamRole;
+import com.chaean.teamchatsa.global.common.aop.annotation.RequireTeamRole;
+import com.chaean.teamchatsa.global.common.dto.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/matches")
+public class MatchController {
+
+	private final MatchService matchService;
+
+	@PostMapping("")
+	@RequireTeamRole({TeamRole.LEADER, TeamRole.CO_LEADER})
+	public ResponseEntity<ApiResponse<Void>> createMatchPost(
+			@AuthenticationPrincipal Long userId,
+			@RequestBody @Valid MatchPostCreateReq req
+	) {
+		matchService.registerMatchPost(userId, req);
+		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success("매치 게시물 등록 성공", null));
+	}
+
+	@DeleteMapping("/{matchId}")
+	@RequireTeamRole({TeamRole.LEADER, TeamRole.CO_LEADER})
+	public ResponseEntity<ApiResponse<Void>> deleteMatchPost(
+			@PathVariable Long matchId,
+			@AuthenticationPrincipal Long userId
+	) {
+		matchService.deleteMatchPost(userId, matchId);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.success(null));
+	}
+
+	@GetMapping("")
+	public ResponseEntity<ApiResponse<Slice<MatchPostListRes>>> getMatchList(
+			@RequestParam(defaultValue = "0") int page,
+			@RequestParam(defaultValue = "10") int size
+	) {
+		return ResponseEntity.ok(ApiResponse.success("매치 목록 조회 성공", matchService.findMatchPostList(page, size)));
+	}
+
+	@GetMapping("/{matchId}")
+	public ResponseEntity<ApiResponse<MatchPostDetailRes>> getMatchDetail(
+			@PathVariable Long matchId
+	) {
+		return ResponseEntity.ok(ApiResponse.success("매치 상세 조회 성공", matchService.findMatchPostDetail(matchId)));
+	}
+
+	@PostMapping("/{matchId}/apply")
+	@RequireTeamRole({TeamRole.LEADER, TeamRole.CO_LEADER})
+	public ResponseEntity<ApiResponse<Void>> applyToMatch(
+			@AuthenticationPrincipal Long userId,
+			@PathVariable Long matchId,
+			@RequestBody MatchApplicationReq req
+			) {
+		matchService.registerMatchApplication(userId, matchId, req);
+		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(null));
+	}
+
+	@PostMapping("/{matchId}/cancel")
+	@RequireTeamRole({TeamRole.LEADER, TeamRole.CO_LEADER})
+	public ResponseEntity<ApiResponse<Void>> cancelMatchApplication(
+			@PathVariable Long matchId,
+			@AuthenticationPrincipal Long userId
+	) {
+		matchService.deleteMatchApplication(userId, matchId);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.success("매치 신청이 취소되었습니다.",null));
+	}
+
+	@PostMapping("/{matchId}/accept/{applicantId}")
+	@RequireTeamRole({TeamRole.LEADER, TeamRole.CO_LEADER})
+	public ResponseEntity<ApiResponse<Void>> acceptMatchApplication(
+			@PathVariable Long matchId,
+			@PathVariable Long applicantId,
+			@AuthenticationPrincipal Long userId
+	) {
+		String teamName = matchService.acceptMatchApplication(matchId, applicantId, userId);
+		String message = "매치 신청이 수락되었습니다. 팀명: " + teamName;
+		return ResponseEntity.ok(ApiResponse.success(message,null));
+	}
+
+	@PostMapping("/{matchId}/reject/{applicantId}")
+	@RequireTeamRole({TeamRole.LEADER, TeamRole.CO_LEADER})
+	public ResponseEntity<ApiResponse<Void>> rejectMatchApplication(
+			@PathVariable Long matchId,
+			@PathVariable Long applicantId,
+			@AuthenticationPrincipal Long userId
+	) {
+		String teamName = matchService.rejectMatchApplication(matchId, applicantId, userId);
+		String message = "매치 신청이 거절되었습니다. 팀명: " + teamName;
+		return ResponseEntity.ok(ApiResponse.success(message,null));
+	}
+}

--- a/src/main/java/com/chaean/teamchatsa/domain/match/dto/request/MatchApplicationReq.java
+++ b/src/main/java/com/chaean/teamchatsa/domain/match/dto/request/MatchApplicationReq.java
@@ -1,0 +1,10 @@
+package com.chaean.teamchatsa.domain.match.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MatchApplicationReq {
+	private String message;
+}

--- a/src/main/java/com/chaean/teamchatsa/domain/match/dto/request/MatchPostCreateReq.java
+++ b/src/main/java/com/chaean/teamchatsa/domain/match/dto/request/MatchPostCreateReq.java
@@ -1,0 +1,43 @@
+package com.chaean.teamchatsa.domain.match.dto.request;
+
+import com.chaean.teamchatsa.domain.match.model.MatchPost;
+import jakarta.validation.constraints.*;
+
+import java.time.LocalDateTime;
+
+public record MatchPostCreateReq(
+		@NotNull
+		@Size(min = 1, max = 100)
+		String title,
+		@NotNull
+		String content,
+		@NotNull
+		@Future
+		LocalDateTime matchDate,
+		@NotNull
+		@Min(-90)
+		@Max(90)
+		double lat,
+		@NotNull
+		@Min(-180)
+		@Max(180)
+		double lng,
+		@NotNull
+		@Size(max = 255)
+		String address,
+		@Size(max = 120)
+		String placeName
+) {
+	public MatchPost toEntity(Long teamId) {
+		return MatchPost.builder()
+				.teamId(teamId)
+				.title(this.title)
+				.content(this.content)
+				.address(this.address)
+				.matchDate(this.matchDate)
+				.lat(this.lat)
+				.lng(this.lng)
+				.placeName(this.placeName)
+				.build();
+	}
+}

--- a/src/main/java/com/chaean/teamchatsa/domain/match/dto/response/MatchPostDetailRes.java
+++ b/src/main/java/com/chaean/teamchatsa/domain/match/dto/response/MatchPostDetailRes.java
@@ -1,0 +1,55 @@
+package com.chaean.teamchatsa.domain.match.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class MatchPostDetailRes {
+	private Long postId;
+	private Long teamId;
+	private String title;
+	private String content;
+	private String placeName;
+	private String address;
+	private double lat;
+	private double lng;
+	private LocalDate matchDate;
+	private LocalTime matchTime;
+	private String teamName;
+	private String teamImg;
+	private String teamLevel;
+
+	public MatchPostDetailRes(Long postId,
+							  Long teamId,
+							  String title,
+							  String content,
+							  String placeName,
+							  String address,
+							  double lat,
+							  double lng,
+							  LocalDateTime matchDateTime,
+							  String teamName,
+							  String teamImg,
+							  String teamLevel) {
+		this.postId = postId;
+		this.teamId = teamId;
+		this.title = title;
+		this.content = content;
+		this.placeName = placeName;
+		this.address = address;
+		this.lat = lat;
+		this.lng = lng;
+		this.matchDate = matchDateTime.toLocalDate();
+		this.matchTime = matchDateTime.toLocalTime();
+		this.teamName = teamName;
+		this.teamImg = teamImg;
+		this.teamLevel = teamLevel;
+	}
+}

--- a/src/main/java/com/chaean/teamchatsa/domain/match/dto/response/MatchPostListRes.java
+++ b/src/main/java/com/chaean/teamchatsa/domain/match/dto/response/MatchPostListRes.java
@@ -1,0 +1,44 @@
+package com.chaean.teamchatsa.domain.match.dto.response;
+
+import com.chaean.teamchatsa.domain.match.model.MatchPostStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class MatchPostListRes {
+	private Long postId;
+	private String matchTitle;
+	private String placeName;
+	private LocalDate matchDate;
+	private LocalTime matchTime;
+	private String teamName;
+	private String matchAddress;
+	private MatchPostStatus postStatus;
+	private String teamLevel;
+
+	public MatchPostListRes(Long postId,
+							String title,
+							String placeName,
+							LocalDateTime matchDateTime,
+							String teamName,
+							String address,
+							MatchPostStatus postStatus,
+							String level) {
+		this.postId = postId;
+		this.matchTitle = title;
+		this.placeName = placeName;
+		this.matchDate = matchDateTime.toLocalDate();
+		this.matchTime = matchDateTime.toLocalTime();
+		this.teamName = teamName;
+		this.matchAddress = address;
+		this.postStatus = postStatus;
+		this.teamLevel = level;
+	}
+}

--- a/src/main/java/com/chaean/teamchatsa/domain/match/model/MatchApplication.java
+++ b/src/main/java/com/chaean/teamchatsa/domain/match/model/MatchApplication.java
@@ -10,7 +10,9 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@Table(name = "match_application")
+@Table(name = "match_application", uniqueConstraints = {
+        @UniqueConstraint(name = "unique_match_post_team", columnNames = {"post_id", "applicant_team_id"})
+})
 public class MatchApplication extends TimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,4 +35,8 @@ public class MatchApplication extends TimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     private MatchApplicationStatus status = MatchApplicationStatus.PENDING;
+
+    public void updateStatus(MatchApplicationStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/chaean/teamchatsa/domain/match/model/MatchPost.java
+++ b/src/main/java/com/chaean/teamchatsa/domain/match/model/MatchPost.java
@@ -45,6 +45,10 @@ public class MatchPost extends DeleteAndTimeEntity {
     @Column(name = "lng", nullable = false)
     private Double lng;
 
+    @NotNull
+    @Column(name = "address", nullable = false, length = 255)
+    private String address;
+
     @Size(max = 120)
     @Column(name = "place_name", length = 120)
     private String placeName;
@@ -57,4 +61,18 @@ public class MatchPost extends DeleteAndTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     private MatchPostStatus status = MatchPostStatus.OPEN;
+
+    public void updateStatus(MatchPostStatus status) {
+        if (this.status == status) {
+            return; // 동일 상태면 무시
+        }
+        if (this.status == MatchPostStatus.CLOSED && status == MatchPostStatus.OPEN) {
+            throw new IllegalStateException("마감된 매치는 다시 열 수 없습니다.");
+        }
+        this.status = status;
+    }
+
+    public void updateOpponent(Long acceptedApplicationId) {
+        this.acceptedApplicationId = acceptedApplicationId;
+    }
 }

--- a/src/main/java/com/chaean/teamchatsa/domain/match/repository/MatchApplicationRepository.java
+++ b/src/main/java/com/chaean/teamchatsa/domain/match/repository/MatchApplicationRepository.java
@@ -1,0 +1,15 @@
+package com.chaean.teamchatsa.domain.match.repository;
+
+import com.chaean.teamchatsa.domain.match.model.MatchApplication;
+import com.chaean.teamchatsa.domain.match.model.MatchApplicationStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MatchApplicationRepository extends JpaRepository<MatchApplication, Long> {
+	Optional<MatchApplication> findByPostIdAndApplicantTeamId(Long matchId, Long teamId);
+	List<MatchApplication> findAllByPostIdAndStatus(Long matchId, MatchApplicationStatus status);
+	boolean existsByPostIdAndApplicantTeamId(Long matchId, Long teamId);
+	Long countByPostId(Long matchId);
+}

--- a/src/main/java/com/chaean/teamchatsa/domain/match/repository/MatchPostRepository.java
+++ b/src/main/java/com/chaean/teamchatsa/domain/match/repository/MatchPostRepository.java
@@ -1,0 +1,11 @@
+package com.chaean.teamchatsa.domain.match.repository;
+
+import com.chaean.teamchatsa.domain.match.model.MatchPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MatchPostRepository extends JpaRepository<MatchPost, Long>, MatchPostRepositoryCustom {
+	Optional<MatchPost> findByIdAndIsDeletedFalse(Long matchId);
+	boolean existsByIdAndIsDeletedFalse(Long matchId);
+}

--- a/src/main/java/com/chaean/teamchatsa/domain/match/repository/MatchPostRepositoryCustom.java
+++ b/src/main/java/com/chaean/teamchatsa/domain/match/repository/MatchPostRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.chaean.teamchatsa.domain.match.repository;
+
+import com.chaean.teamchatsa.domain.match.dto.response.MatchPostDetailRes;
+import com.chaean.teamchatsa.domain.match.dto.response.MatchPostListRes;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface MatchPostRepositoryCustom {
+
+	/** MatchPost 목록 조회 (커서 기반 페이징) */
+	Slice<MatchPostListRes> findMatchPostListWithPagination(Pageable pageable);
+	MatchPostDetailRes findMatchPostDetailById(Long matchId);
+}

--- a/src/main/java/com/chaean/teamchatsa/domain/match/repository/MatchPostRepositoryImpl.java
+++ b/src/main/java/com/chaean/teamchatsa/domain/match/repository/MatchPostRepositoryImpl.java
@@ -1,0 +1,99 @@
+package com.chaean.teamchatsa.domain.match.repository;
+
+import com.chaean.teamchatsa.domain.match.dto.response.MatchPostDetailRes;
+import com.chaean.teamchatsa.domain.match.dto.response.MatchPostListRes;
+import com.chaean.teamchatsa.domain.match.model.QMatchPost;
+import com.chaean.teamchatsa.domain.team.model.QTeam;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * MatchPost QueryDSL 구현체
+ * - 네이밍: MatchPostRepositoryImpl (Spring이 자동 인식)
+ * - @Repository 필수
+ */
+@Repository
+@RequiredArgsConstructor
+public class MatchPostRepositoryImpl implements MatchPostRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Slice<MatchPostListRes> findMatchPostListWithPagination(Pageable pageable) {
+		QMatchPost mp = QMatchPost.matchPost;
+		QTeam t = QTeam.team;
+
+		List<MatchPostListRes> content = queryFactory
+				.select(Projections.constructor(
+						MatchPostListRes.class,
+						mp.id,
+						mp.title,
+						mp.placeName,
+						mp.matchDate,
+						t.name,
+						mp.address,
+						mp.status,
+						t.level
+				))
+				.from(mp)
+				.leftJoin(t).on(t.id.eq(mp.teamId).and(t.isDeleted.eq(false)))
+				.where(mp.isDeleted.eq(false))
+				.orderBy(mp.createdAt.desc(), mp.id.desc())
+				.offset(pageable.getOffset())
+				.limit(pageable.getPageSize() + 1)  // hasNext 판단용
+				.fetch();
+
+		// Slice 생성 (무한 스크롤)
+		return createSlice(content, pageable);
+	}
+
+	@Override
+	public MatchPostDetailRes findMatchPostDetailById(Long matchId) {
+		QMatchPost mp = QMatchPost.matchPost;
+		QTeam t = QTeam.team;
+
+		MatchPostDetailRes content = queryFactory
+				.select(Projections.constructor(
+						MatchPostDetailRes.class,
+						mp.id,
+						mp.teamId,
+						mp.title,
+						mp.content,
+						mp.placeName,
+						mp.address,
+						mp.lat,
+						mp.lng,
+						mp.matchDate,
+						t.name,
+						t.img,
+						t.level
+				))
+				.from(mp)
+				.leftJoin(t).on(
+						t.id.eq(mp.teamId)
+								.and(t.isDeleted.eq(false))
+				)
+				.where(mp.id.eq(matchId)
+						.and(mp.isDeleted.eq(false)))
+				.fetchOne();
+
+		return content;
+	}
+
+	/** Slice 생성 헬퍼 메서드 */
+	private <T> Slice<T> createSlice(List<T> content, Pageable pageable) {
+		boolean hasNext = false;
+		if (content.size() > pageable.getPageSize()) {
+			content.remove(pageable.getPageSize());
+			hasNext = true;
+		}
+		return new SliceImpl<>(content, pageable, hasNext);
+	}
+}

--- a/src/main/java/com/chaean/teamchatsa/domain/match/service/MatchService.java
+++ b/src/main/java/com/chaean/teamchatsa/domain/match/service/MatchService.java
@@ -1,0 +1,221 @@
+package com.chaean.teamchatsa.domain.match.service;
+
+import com.chaean.teamchatsa.domain.match.dto.request.MatchApplicationReq;
+import com.chaean.teamchatsa.domain.match.dto.request.MatchPostCreateReq;
+import com.chaean.teamchatsa.domain.match.dto.response.MatchPostDetailRes;
+import com.chaean.teamchatsa.domain.match.dto.response.MatchPostListRes;
+import com.chaean.teamchatsa.domain.match.model.*;
+import com.chaean.teamchatsa.domain.match.repository.MatchApplicationRepository;
+import com.chaean.teamchatsa.domain.match.repository.MatchPostRepository;
+import com.chaean.teamchatsa.domain.team.model.Team;
+import com.chaean.teamchatsa.domain.team.repository.TeamMemberRepository;
+import com.chaean.teamchatsa.domain.team.repository.TeamRepository;
+import com.chaean.teamchatsa.global.common.aop.annotation.DistributedLock;
+import com.chaean.teamchatsa.global.exception.BusinessException;
+import com.chaean.teamchatsa.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MatchService {
+
+	private final MatchPostRepository matchPostRepo;
+	private final MatchApplicationRepository matchApplicationRepo;
+	private final TeamMemberRepository teamMemberRepo;
+	private final TeamRepository teamRepo;
+
+	/** 매치 게시물 등록 */
+	@Transactional
+	public void registerMatchPost(Long userId, MatchPostCreateReq req) {
+		if (req.matchDate().isBefore(LocalDateTime.now())) {
+			throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "매치 날짜는 현재 시각 이후여야 합니다.");
+		}
+
+		Long teamId = teamMemberRepo.findTeamIdByUserIdAndIsDeletedFalse(userId);
+		if (teamId == null) {
+			throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "사용자가 속한 팀이 없습니다.");
+		}
+
+		MatchPost matchPost = req.toEntity(teamId);
+
+		matchPostRepo.save(matchPost);
+	}
+
+	/** 매치 게시물 삭제 */
+	@Transactional
+	public void deleteMatchPost(Long userId, Long matchId) {
+		MatchPost matchPost = matchPostRepo.findByIdAndIsDeletedFalse(matchId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.MATCH_POST_NOT_FOUND));
+
+		Long teamId = teamMemberRepo.findTeamIdByUserIdAndIsDeletedFalse(userId);
+		if (teamId == null || !matchPost.getTeamId().equals(teamId)) {
+			throw new BusinessException(ErrorCode.FORBIDDEN, "매치 게시물을 삭제할 권한이 없습니다.");
+		}
+
+		long applicationCount = matchApplicationRepo.countByPostId(matchId);
+		if (applicationCount > 0) {
+			throw new BusinessException(ErrorCode.INVALID_STATE, "신청이 있는 매치는 삭제할 수 없습니다.");
+		}
+
+		matchPostRepo.delete(matchPost);
+	}
+
+	/** 매치 게시물 목록 조회 */
+	@Transactional(readOnly = true)
+	public Slice<MatchPostListRes> findMatchPostList(int page, int size) {
+		Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending().and(Sort.by("id").descending()));
+
+		return matchPostRepo.findMatchPostListWithPagination(pageable);
+	}
+
+	/** 매치 게시물 상세 조회 */
+	@Transactional(readOnly = true)
+	public MatchPostDetailRes findMatchPostDetail(Long matchId) {
+		MatchPostDetailRes content = matchPostRepo.findMatchPostDetailById(matchId);
+		if (content == null) {
+			throw new BusinessException(ErrorCode.MATCH_POST_NOT_FOUND);
+		}
+
+		return content;
+	}
+
+	/** 매치 신청 */
+	@Transactional
+	public void registerMatchApplication(Long userId, Long matchId, MatchApplicationReq req) {
+		MatchPost matchPost = matchPostRepo.findByIdAndIsDeletedFalse(matchId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.MATCH_POST_NOT_FOUND));
+
+		if (matchPost.getStatus() != MatchPostStatus.OPEN) {
+			throw new BusinessException(ErrorCode.INVALID_STATE, "마감된 매치입니다.");
+		}
+
+		Long teamId = teamMemberRepo.findTeamIdByUserIdAndIsDeletedFalse(userId);
+		if (teamId == null) {
+			throw new BusinessException(ErrorCode.TEAM_NOT_FOUND, "사용자가 속한 팀이 없습니다.");
+		}
+
+		if (matchPost.getTeamId().equals(teamId)) {
+			throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "자신의 팀이 작성한 매치에는 신청할 수 없습니다.");
+		}
+
+		boolean alreadyApplied = matchApplicationRepo.existsByPostIdAndApplicantTeamId(matchPost.getId(), teamId);
+		if (alreadyApplied) {
+			throw new BusinessException(ErrorCode.DUPLICATE_RESOURCE, "이미 신청한 매치입니다.");
+		}
+
+		MatchApplication matchApplication = MatchApplication.builder()
+				.postId(matchPost.getId())
+				.applicantTeamId(teamId)
+				.message(req.getMessage())
+				.build();
+
+		try {
+			matchApplicationRepo.save(matchApplication);
+		} catch (DataIntegrityViolationException e) {
+			throw new BusinessException(ErrorCode.DUPLICATE_RESOURCE, "이미 신청한 매치입니다.");
+		}
+	}
+
+	/** 매치 신청 취소 */
+	@Transactional
+	public void deleteMatchApplication(Long userId, Long matchId) {
+		if (!matchPostRepo.existsByIdAndIsDeletedFalse(matchId)) {
+			throw new BusinessException(ErrorCode.MATCH_POST_NOT_FOUND);
+		}
+
+		Long teamId = teamMemberRepo.findTeamIdByUserIdAndIsDeletedFalse(userId);
+		if (teamId == null) {
+			throw new BusinessException(ErrorCode.TEAM_NOT_FOUND, "사용자가 속한 팀이 없습니다.");
+		}
+
+		MatchApplication matchApplication = matchApplicationRepo
+				.findByPostIdAndApplicantTeamId(matchId, teamId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.APPLICATION_NOT_FOUND, "매치 신청을 찾을 수 없습니다."));
+
+		if (matchApplication.getStatus() != MatchApplicationStatus.PENDING) {
+			throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "대기 중인 신청만 취소할 수 있습니다.");
+		}
+
+		matchApplication.updateStatus(MatchApplicationStatus.CANCELLED);
+	}
+
+	/** 매치 신청 수락 */
+	@DistributedLock(key = "'match:' + #matchId")
+	@Transactional
+	public String acceptMatchApplication(Long matchId, Long applicantId, Long userId) {
+		MatchPost matchPost = matchPostRepo.findByIdAndIsDeletedFalse(matchId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.MATCH_POST_NOT_FOUND));
+
+		if (matchPost.getMatchDate().isBefore(LocalDateTime.now())) {
+			throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "지난 매치에는 신청을 수락할 수 없습니다.");
+		}
+
+		if (matchPost.getStatus() != MatchPostStatus.OPEN) {
+			throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "이미 마감된 게시물입니다.");
+		}
+
+		Long teamId = teamMemberRepo.findTeamIdByUserIdAndIsDeletedFalse(userId);
+		if (!matchPost.getTeamId().equals(teamId)) {
+			throw new BusinessException(ErrorCode.FORBIDDEN, "해당 매치의 팀 멤버가 아닙니다.");
+		}
+
+		MatchApplication matchApplication = matchApplicationRepo.findById(applicantId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.APPLICATION_NOT_FOUND, "매치 신청을 찾을 수 없습니다."));
+
+		if (matchApplication.getStatus() != MatchApplicationStatus.PENDING) {
+			throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "이미 처리된 신청입니다.");
+		}
+
+		matchApplication.updateStatus(MatchApplicationStatus.ACCEPTED);
+		matchPost.updateStatus(MatchPostStatus.CLOSED);
+		matchPost.updateOpponent(applicantId);
+
+		List<MatchApplication> pendingApplications = matchApplicationRepo.findAllByPostIdAndStatus(
+				matchPost.getId(), MatchApplicationStatus.PENDING);
+
+		pendingApplications.forEach(app -> {
+			if (!app.getId().equals(applicantId)) {
+				app.updateStatus(MatchApplicationStatus.REJECTED);
+			}
+		});
+
+		Team team = teamRepo.findByIdAndIsDeletedFalse(matchApplication.getApplicantTeamId())
+				.orElseThrow(() -> new BusinessException(ErrorCode.TEAM_NOT_FOUND, "신청한 팀을 찾을 수 없습니다."));
+
+		return team.getName();
+	}
+
+	/** 매치 신청 거절 */
+	@Transactional
+	public String rejectMatchApplication(Long matchId, Long applicantId, Long userId) {
+		MatchPost matchPost = matchPostRepo.findByIdAndIsDeletedFalse(matchId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.MATCH_POST_NOT_FOUND));
+
+		Long teamId = teamMemberRepo.findTeamIdByUserIdAndIsDeletedFalse(userId);
+		if (!matchPost.getTeamId().equals(teamId)) {
+			throw new BusinessException(ErrorCode.FORBIDDEN, "권한이 없습니다.");
+		}
+
+		MatchApplication matchApplication = matchApplicationRepo.findById(applicantId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.APPLICATION_NOT_FOUND, "매치 신청을 찾을 수 없습니다."));
+
+		matchApplication.updateStatus(MatchApplicationStatus.REJECTED);
+
+		Team team = teamRepo.findByIdAndIsDeletedFalse(matchApplication.getApplicantTeamId())
+				.orElseThrow(() -> new BusinessException(ErrorCode.TEAM_NOT_FOUND, "신청한 팀을 찾을 수 없습니다."));
+
+		return team.getName();
+	}
+}

--- a/src/main/java/com/chaean/teamchatsa/domain/team/controller/TeamController.java
+++ b/src/main/java/com/chaean/teamchatsa/domain/team/controller/TeamController.java
@@ -31,15 +31,16 @@ public class TeamController {
 	public ResponseEntity<ApiResponse<Void>> createTeam(@AuthenticationPrincipal Long userId, @RequestBody @Validated TeamCreateReq req) {
 		teamService.registerTeam(userId, req);
 
-		return ResponseEntity.status(HttpStatus.CREATED).body( ApiResponse.success(null));
+		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(null));
 	}
 
 	/** 팀 목록 조회 (무한 스크롤) */
 	@GetMapping("")
 	public ResponseEntity<ApiResponse<Slice<TeamListRes>>> getTeamList(
-			@PageableDefault(size = 20) Pageable pageable
+			@RequestParam(defaultValue = "0") int page,
+			@RequestParam(defaultValue = "10") int size
 	) {
-		Slice<TeamListRes> res = teamService.findTeamList(pageable);
+		Slice<TeamListRes> res = teamService.findTeamList(page, size);
 		return ResponseEntity.ok(ApiResponse.success(res));
 	}
 
@@ -64,7 +65,7 @@ public class TeamController {
 	@RequireTeamRole(TeamRole.LEADER)
 	public ResponseEntity<ApiResponse<Void>> deleteTeam(@PathVariable Long teamId) {
 		teamService.deleteTeam(teamId);
-		return ResponseEntity.ok(ApiResponse.success("팀이 삭제되었습니다.", null));
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).body(ApiResponse.success("팀이 삭제되었습니다.", null));
 	}
 
 	/** 팀 정보 수정 - LEADER 또는 CO_LEADER만 가능

--- a/src/main/java/com/chaean/teamchatsa/domain/team/dto/request/TeamCreateReq.java
+++ b/src/main/java/com/chaean/teamchatsa/domain/team/dto/request/TeamCreateReq.java
@@ -13,6 +13,8 @@ public record TeamCreateReq(
 		ContactType contactType,
 		@NotNull
 		String contact,
-		String imgUrl
+		String imgUrl,
+		@NotNull
+		String level
 ) {
 }

--- a/src/main/java/com/chaean/teamchatsa/domain/team/dto/response/TeamDetailRes.java
+++ b/src/main/java/com/chaean/teamchatsa/domain/team/dto/response/TeamDetailRes.java
@@ -9,7 +9,8 @@ public record TeamDetailRes(
 		String area,
 		String img,
 		String description,
-		Long memberCount
+		Long memberCount,
+		String level
 ) {
 	public static TeamDetailRes fromEntity(Team team, Long memberCount) {
 		return new TeamDetailRes(
@@ -19,7 +20,8 @@ public record TeamDetailRes(
 				team.getArea(),
 				team.getImg(),
 				team.getDescription(),
-				memberCount
+				memberCount,
+				team.getLevel()
 		);
 	}
 }

--- a/src/main/java/com/chaean/teamchatsa/domain/team/model/Team.java
+++ b/src/main/java/com/chaean/teamchatsa/domain/team/model/Team.java
@@ -11,7 +11,9 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@Table(name = "team")
+@Table(name = "team", uniqueConstraints = {
+        @UniqueConstraint(name = "unique_team_leader", columnNames = {"leader_user_id"})
+})
 public class Team extends DeleteAndTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -44,6 +46,10 @@ public class Team extends DeleteAndTimeEntity {
     @NotNull
     @Column(name = "contact", nullable = false, length = 50)
     private String contact;
+
+    @NotNull
+    @Column(name = "level", nullable = false, length = 20)
+    private String level;
 
     @Size(max = 255)
     @Column(name = "img")

--- a/src/main/java/com/chaean/teamchatsa/domain/team/model/TeamMember.java
+++ b/src/main/java/com/chaean/teamchatsa/domain/team/model/TeamMember.java
@@ -10,7 +10,10 @@ import lombok.*;
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "team_member")
+@Table(name = "team_member", uniqueConstraints = {
+        @UniqueConstraint(name = "unique_team_user", columnNames = {"user_id"}),
+        @UniqueConstraint(name = "unique_team_team_user", columnNames = {"team_id", "user_id"})
+})
 public class TeamMember extends DeleteAndTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/chaean/teamchatsa/domain/team/repository/TeamMemberRepository.java
+++ b/src/main/java/com/chaean/teamchatsa/domain/team/repository/TeamMemberRepository.java
@@ -2,11 +2,24 @@ package com.chaean.teamchatsa.domain.team.repository;
 
 import com.chaean.teamchatsa.domain.team.model.TeamMember;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     boolean existsByUserIdAndIsDeletedFalse(Long userId);
+
     Long countByTeamIdAndIsDeletedFalse(Long teamId);
+
     Optional<TeamMember> findByTeamIdAndUserIdAndIsDeletedFalse(Long teamId, Long userId);
+
+    Optional<TeamMember> findByUserIdAndIsDeletedFalse(Long userId);
+
+    @Query("""
+        SELECT tm.teamId
+          FROM TeamMember tm
+         WHERE tm.userId = :userId
+           AND tm.isDeleted = false
+    """)
+    Long findTeamIdByUserIdAndIsDeletedFalse(Long userId);
 }

--- a/src/main/java/com/chaean/teamchatsa/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/chaean/teamchatsa/domain/team/repository/TeamRepository.java
@@ -9,34 +9,11 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
-public interface TeamRepository extends JpaRepository<Team, Long> {
+public interface TeamRepository extends JpaRepository<Team, Long>, TeamRepositoryCustom {
 
     Optional<Team> findByIdAndIsDeletedFalse(Long teamId);
 
     boolean existsByIdAndIsDeletedFalse(Long teamId);
 
     boolean existsByLeaderUserIdAndIsDeletedFalse(Long userId);
-
-    @Query("""
-        SELECT new com.chaean.teamchatsa.domain.team.dto.response.TeamListRes(
-                t.id,
-                t.name,
-                t.area,
-                t.img,
-                t.description,
-                coalesce(
-                    cast((
-                        select count(tm.id)
-                        from TeamMember tm
-                        where tm.teamId= t.id
-                          and tm.isDeleted = false
-                    ) as long),
-                    0L
-                )
-            )
-        FROM Team t
-        WHERE t.isDeleted = false
-        ORDER BY t.createdAt desc, t.id desc 
-    """)
-    Slice<TeamListRes> findTeamListSlice(Pageable pageable);
 }

--- a/src/main/java/com/chaean/teamchatsa/domain/team/repository/TeamRepositoryCustom.java
+++ b/src/main/java/com/chaean/teamchatsa/domain/team/repository/TeamRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.chaean.teamchatsa.domain.team.repository;
+
+import com.chaean.teamchatsa.domain.team.dto.response.TeamListRes;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public interface TeamRepositoryCustom {
+
+	/** 팀 목록 조회 (커서 기반 페이징) */
+	Slice<TeamListRes> findTeamListWithPagination(Pageable pageable);
+}

--- a/src/main/java/com/chaean/teamchatsa/domain/team/repository/TeamRepositoryImpl.java
+++ b/src/main/java/com/chaean/teamchatsa/domain/team/repository/TeamRepositoryImpl.java
@@ -1,0 +1,69 @@
+package com.chaean.teamchatsa.domain.team.repository;
+
+import com.chaean.teamchatsa.domain.team.dto.response.TeamListRes;
+import com.chaean.teamchatsa.domain.team.model.QTeam;
+import com.chaean.teamchatsa.domain.team.model.QTeamMember;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * Team QueryDSL 구현체
+ * - 네이밍: TeamRepositoryImpl (Spring이 자동 인식)
+ * - @Repository 필수
+ */
+@Repository
+@RequiredArgsConstructor
+public class TeamRepositoryImpl implements TeamRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+	/**
+	 * 팀 목록 조회 (QueryDSL 최적화)
+	 * LEFT JOIN + GROUP BY 방식으로 서브쿼리 제거
+	 */
+	@Override
+	public Slice<TeamListRes> findTeamListWithPagination(Pageable pageable) {
+		QTeam t = QTeam.team;
+		QTeamMember tm = QTeamMember.teamMember;
+
+		List<TeamListRes> content = queryFactory
+				.select(Projections.constructor(
+						TeamListRes.class,
+						t.id,
+						t.name,
+						t.area,
+						t.img,
+						t.description,
+						tm.id.count()
+				))
+				.from(t)
+				.leftJoin(tm).on(
+						tm.teamId.eq(t.id)
+							.and(tm.isDeleted.eq(false))
+				)
+				.where(t.isDeleted.eq(false))
+				.groupBy(t.id, t.name, t.area, t.img, t.description, t.createdAt)
+				.orderBy(t.createdAt.desc(), t.id.desc())
+				.offset(pageable.getOffset())
+				.limit(pageable.getPageSize() + 1)
+				.fetch();
+
+		// Slice 생성 (무한 스크롤)
+		return createSlice(content, pageable);
+	}
+
+	private <T> Slice<T> createSlice(List<T> content, Pageable pageable) {
+		boolean hasNext = false;
+		if (content.size() > pageable.getPageSize()) {
+			content.remove(pageable.getPageSize());
+			hasNext = true;
+		}
+		return new SliceImpl<>(content, pageable, hasNext);
+	}
+}

--- a/src/main/java/com/chaean/teamchatsa/domain/team/service/TeamService.java
+++ b/src/main/java/com/chaean/teamchatsa/domain/team/service/TeamService.java
@@ -16,8 +16,10 @@ import com.chaean.teamchatsa.global.exception.BusinessException;
 import com.chaean.teamchatsa.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,6 +42,9 @@ public class TeamService {
 			throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE, "이미 리더로 존재하는 팀이 존재합니다. 팀은 1개만 생성가능합니다.");
 		}
 
+		// TODO : 중복 팀명 체크
+
+		// TODO : of 패턴으로 전환
 		Team team = Team.builder()
 				.leaderUserId(userId)
 				.name(req.name())
@@ -48,7 +53,10 @@ public class TeamService {
 				.contactType(req.contactType())
 				.contact(req.contact())
 				.img(req.imgUrl())
+				.level(req.level())
 				.build();
+
+		teamRepo.save(team);
 
 		TeamMember teamMember = TeamMember.builder()
 				.teamId(team.getId())
@@ -56,14 +64,14 @@ public class TeamService {
 				.role(TeamRole.LEADER)
 				.build();
 
-		teamRepo.save(team);
 		teamMemberRepo.save(teamMember);
 	}
 
 	@Transactional(readOnly = true)
 	@Loggable
-	public Slice<TeamListRes> findTeamList(Pageable pageable) {
-		return teamRepo.findTeamListSlice(pageable);
+	public Slice<TeamListRes> findTeamList(int page, int size) {
+		Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+		return teamRepo.findTeamListWithPagination(pageable);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/chaean/teamchatsa/global/common/aop/annotation/DistributedLock.java
+++ b/src/main/java/com/chaean/teamchatsa/global/common/aop/annotation/DistributedLock.java
@@ -1,0 +1,40 @@
+package com.chaean.teamchatsa.global.common.aop.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 분산 락 어노테이션
+ * - Redis 기반 분산 락을 적용하여 동시성 제어
+ * - SpEL 표현식을 통한 동적 락 키 생성 지원
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+	/**
+	 * 락의 키 값 (SpEL 표현식 지원)
+	 * 예: "match:#{#matchId}", "match:#{#matchId}:application:#{#applicantId}"
+	 */
+	String key();
+
+	/**
+	 * 락 획득을 시도하는 최대 대기 시간 (ms)
+	 * 이 시간 동안 락 획득에 실패하면 예외 발생
+	 */
+	long waitTime() default 3000L;
+
+	/**
+	 * 락을 획득한 후 자동으로 해제되는 시간 (ms)
+	 * 메서드 실행이 이 시간을 초과하면 자동으로 락이 해제됨
+	 */
+	long leaseTime() default 5000L;
+
+	/**
+	 * 시간 단위
+	 */
+	TimeUnit timeUnit() default TimeUnit.MILLISECONDS;
+}

--- a/src/main/java/com/chaean/teamchatsa/global/common/aop/annotation/RequireTeamRole.java
+++ b/src/main/java/com/chaean/teamchatsa/global/common/aop/annotation/RequireTeamRole.java
@@ -7,20 +7,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * 특정 TeamRole을 가진 사용자만 접근할 수 있도록 제한하는 어노테이션.
- * 메서드의 파라미터 중 teamId를 통해 사용자의 팀 권한을 검증.
- * userId는 파라미터에서 찾지 못하면 SecurityContext에서 자동으로 추출.
- */
+/** 특정 TeamRole을 가진 사용자만 접근할 수 있도록 제한하는 어노테이션. */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface RequireTeamRole {
-    /** 접근 가능한 팀 역할 목록 - TeamRole 배열 */
-    TeamRole[] value();
-
-    /** teamId 파라미터의 이름 - 기본값: "teamId") */
-    String teamIdParam() default "teamId";
-
-    /** userId 파라미터의 이름 - 기본값: "userId" */
-    String userIdParam() default "userId";
+	/** 접근 가능한 팀 역할 목록 - TeamRole 배열 */
+	TeamRole[] value();
 }

--- a/src/main/java/com/chaean/teamchatsa/global/common/aop/aspect/DistributedLockAspect.java
+++ b/src/main/java/com/chaean/teamchatsa/global/common/aop/aspect/DistributedLockAspect.java
@@ -1,0 +1,73 @@
+package com.chaean.teamchatsa.global.common.aop.aspect;
+
+import com.chaean.teamchatsa.global.common.aop.annotation.DistributedLock;
+import com.chaean.teamchatsa.global.exception.BusinessException;
+import com.chaean.teamchatsa.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+
+/**
+ * @DistributedLock 분산 락 구현
+ */
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DistributedLockAspect {
+
+	private final RedissonClient redissonClient;
+	private final ExpressionParser parser = new SpelExpressionParser();
+
+	@Around("@annotation(distributedLock)")
+	public Object lock(ProceedingJoinPoint joinPoint, DistributedLock distributedLock) throws Throwable {
+		MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+		String[] parameterNames = signature.getParameterNames();
+		Object[] args = joinPoint.getArgs();
+
+		StandardEvaluationContext context = new StandardEvaluationContext();
+		for (int i = 0; i < parameterNames.length; i++) {
+			context.setVariable(parameterNames[i], args[i]);
+		}
+
+		String lockKey = parser.parseExpression(distributedLock.key()).getValue(context, String.class);
+		RLock lock = redissonClient.getLock(lockKey);
+
+		log.info("[분산 락] 락 획득 시도: {}", lockKey);
+
+		try {
+			// 락 획득 시도
+			boolean acquired = lock.tryLock(
+					distributedLock.waitTime(),
+					distributedLock.leaseTime(),
+					distributedLock.timeUnit()
+			);
+
+			if (!acquired) {
+				log.error("[분산 락] 락 획득 실패: {}", lockKey);
+				throw new BusinessException(ErrorCode.LOCK_ACQUISITION_FAILED, "다른 요청이 처리 중입니다. 잠시 후 다시 시도해주세요.");
+			}
+
+			log.info("[분산 락] 락 획득 성공: {}", lockKey);
+
+			// 비즈니스 로직 실행
+			return joinPoint.proceed();
+
+		} finally {
+			// 락 해제
+			if (lock.isHeldByCurrentThread()) {
+				lock.unlock();
+				log.info("[분산 락] 락 해제 완료: {}", lockKey);
+			}
+		}
+	}
+}

--- a/src/main/java/com/chaean/teamchatsa/global/common/aop/aspect/TeamRoleAspect.java
+++ b/src/main/java/com/chaean/teamchatsa/global/common/aop/aspect/TeamRoleAspect.java
@@ -8,22 +8,17 @@ import com.chaean.teamchatsa.global.exception.BusinessException;
 import com.chaean.teamchatsa.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
-import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
 import java.util.Arrays;
 
 /**
  * @RequireTeamRole 어노테이션이 붙은 메서드에 대한 팀 역할 기반 접근 제어를 처리하는 Aspect입니다.
- * 사용자의 팀 내 역할을 확인하여 지정된 역할을 가진 사용자만 메서드를 실행할 수 있도록 제한합니다.
+ * SecurityContext에서 userId를 추출하여 사용자의 팀 권한을 검증합니다.
  */
 @Slf4j
 @Aspect
@@ -31,119 +26,56 @@ import java.util.Arrays;
 @RequiredArgsConstructor
 public class TeamRoleAspect {
 
-    private final TeamMemberRepository teamMemberRepository;
+	private final TeamMemberRepository teamMemberRepository;
 
-    /**
-     * @RequireTeamRole 어노테이션이 붙은 메서드 실행 전에 팀 역할을 검증
-     * userId는 파라미터에서 찾지 못하면 SecurityContext에서 자동으로 추출
-     */
-    @Before("@annotation(requireTeamRole)")
-    public void checkTeamRole(JoinPoint joinPoint, RequireTeamRole requireTeamRole) {
-        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-        Method method = signature.getMethod();
-        Object[] args = joinPoint.getArgs();
-        Parameter[] parameters = method.getParameters();
+	/**
+	 * @RequireTeamRole 어노테이션이 붙은 메서드 실행 전에 팀 역할을 검증
+	 * userId는 파라미터에서 찾지 못하면 SecurityContext에서 자동으로 추출
+	 */
+	@Before("@annotation(requireTeamRole)")
+	public void checkTeamRole(RequireTeamRole requireTeamRole) {
+		Long userId = getUserIdFromSecurityContext();
 
-        // 파라미터에서 teamId 추출
-        Long teamId = extractParameterValue(parameters, args, requireTeamRole.teamIdParam(), Long.class);
+		// userId 기준으로 팀 멤버 조회 (전제: 한 유저는 하나의 팀만 가진다)
+		TeamMember teamMember = teamMemberRepository
+				.findByUserIdAndIsDeletedFalse(userId)
+				.orElseThrow(() -> {
+					log.warn("[권한 검증 실패] 팀에 소속되지 않은 사용자입니다. userId: {}", userId);
+					return new BusinessException(ErrorCode.NOT_TEAM_MEMBER);
+				});
 
-        if (teamId == null) {
-            log.error("[팀 권한 검증 실패] teamId 파라미터를 찾을 수 없습니다. 파라미터명: {}", requireTeamRole.teamIdParam());
-            throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
-        }
+		TeamRole userRole = teamMember.getRole();
+		TeamRole[] requiredRoles = requireTeamRole.value();
 
-        // 파라미터에서 userId 추출 시도, 없으면 SecurityContext에서 추출
-        Long userId = extractParameterValue(parameters, args, requireTeamRole.userIdParam(), Long.class);
-        if (userId == null) {
-            userId = getUserIdFromSecurityContext();
-        }
+		boolean hasRequiredRole = Arrays.stream(requiredRoles)
+				.anyMatch(role -> role == userRole);
 
-        // 람다에서 사용하기 위한 final 변수
-        final Long finalUserId = userId;
+		if (!hasRequiredRole) {
+			log.warn("[팀 권한 검증 실패] 사용자의 역할이 요구 조건을 충족하지 못합니다. " +
+							"userId: {}, 현재 역할: {}, 요구 역할: {}",
+					userId, userRole, Arrays.toString(requiredRoles));
+			throw new BusinessException(ErrorCode.INSUFFICIENT_TEAM_ROLE);
+		}
 
-        // 팀 멤버 조회
-        TeamMember teamMember = teamMemberRepository
-                .findByTeamIdAndUserIdAndIsDeletedFalse(teamId, finalUserId)
-                .orElseThrow(() -> {
-                    log.warn("[팀 권한 검증 실패] 사용자가 팀 멤버가 아닙니다. userId: {}, teamId: {}", finalUserId, teamId);
-                    return new BusinessException(ErrorCode.NOT_TEAM_MEMBER);
-                });
+		log.info("[팀 권한 검증 성공] userId: {}, 역할: {}", userId, userRole);
+	}
 
-        // 요구되는 역할 확인
-        TeamRole[] requiredRoles = requireTeamRole.value();
-        TeamRole userRole = teamMember.getRole();
+	/** SecurityContext에서 현재 인증된 사용자의 userId를 추출 */
+	private Long getUserIdFromSecurityContext() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        boolean hasRequiredRole = Arrays.asList(requiredRoles).contains(userRole);
+		if (authentication == null || !authentication.isAuthenticated()) {
+			log.error("[팀 권한 검증 실패] SecurityContext에 인증 정보가 없습니다.");
+			throw new BusinessException(ErrorCode.UNAUTHORIZED);
+		}
 
-        if (!hasRequiredRole) {
-            log.warn("[팀 권한 검증 실패] 사용자의 역할이 요구 조건을 충족하지 못합니다. userId: {}, 현재 역할: {}, 요구 역할: {}, teamId: {}",
-                    finalUserId, userRole, Arrays.toString(requiredRoles), teamId);
-            throw new BusinessException(ErrorCode.INSUFFICIENT_TEAM_ROLE);
-        }
+		Object principal = authentication.getPrincipal();
+		if (principal instanceof Long) {
+			return (Long) principal;
+		}
 
-        log.info("[팀 권한 검증 성공] userId: {}, 역할: {}, teamId: {}", finalUserId, userRole, teamId);
-    }
-
-    /** SecurityContext에서 현재 인증된 사용자의 userId를 추출 */
-    private Long getUserIdFromSecurityContext() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        if (authentication == null || !authentication.isAuthenticated()) {
-            log.error("[팀 권한 검증 실패] SecurityContext에 인증 정보가 없습니다.");
-            throw new BusinessException(ErrorCode.UNAUTHORIZED);
-        }
-
-        Object principal = authentication.getPrincipal();
-
-        if (principal instanceof Long) {
-            return (Long) principal;
-        }
-
-        log.error("[팀 권한 검증 실패] principal 타입이 지원되지 않습니다. type: {}", principal.getClass().getName());
-        throw new BusinessException(ErrorCode.UNAUTHORIZED);
-    }
-
-    /** 메서드 파라미터에서 지정된 이름의 값을 추출 */
-    private <T> T extractParameterValue(Parameter[] parameters, Object[] args, String paramName, Class<T> expectedType) {
-        for (int i = 0; i < parameters.length; i++) {
-            Parameter parameter = parameters[i];
-
-            // 파라미터 이름이 일치하는 경우
-            if (parameter.getName().equals(paramName)) {
-                Object value = args[i];
-                if (value != null && expectedType.isInstance(value)) {
-                    return expectedType.cast(value);
-                }
-            }
-
-            // @PathVariable, @RequestParam 등의 어노테이션에서 value 확인
-            for (Annotation annotation : parameter.getAnnotations()) {
-                String annotationValue = getAnnotationValue(annotation);
-                if (paramName.equals(annotationValue)) {
-                    Object value = args[i];
-                    if (value != null && expectedType.isInstance(value)) {
-                        return expectedType.cast(value);
-                    }
-                }
-            }
-        }
-        return null;
-    }
-
-    /** 어노테이션에서 value 속성 추출 */
-    private String getAnnotationValue(Annotation annotation) {
-        try {
-            Method valueMethod = annotation.annotationType().getMethod("value");
-            Object value = valueMethod.invoke(annotation);
-            if (value instanceof String) {
-                return (String) value;
-            } else if (value instanceof String[]) {
-                String[] values = (String[]) value;
-                return values.length > 0 ? values[0] : null;
-            }
-        } catch (Exception e) {
-            // value 메서드가 없거나 호출 실패 시 무시
-        }
-        return null;
-    }
+		log.error("[팀 권한 검증 실패] principal 타입이 지원되지 않습니다. type: {}",
+				principal.getClass().getName());
+		throw new BusinessException(ErrorCode.UNAUTHORIZED);
+	}
 }

--- a/src/main/java/com/chaean/teamchatsa/global/config/QueryDslConfig.java
+++ b/src/main/java/com/chaean/teamchatsa/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.chaean.teamchatsa.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/src/main/java/com/chaean/teamchatsa/global/config/RedissonConfig.java
+++ b/src/main/java/com/chaean/teamchatsa/global/config/RedissonConfig.java
@@ -1,0 +1,35 @@
+package com.chaean.teamchatsa.global.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+	@Value("${spring.data.redis.host}")
+	private String redisHost;
+
+	@Value("${spring.data.redis.port}")
+	private int redisPort;
+
+	@Bean
+	public RedissonClient redissonClient() {
+		Config config = new Config();
+
+		// Single Server 모드
+		config.useSingleServer()
+				.setAddress("redis://" + redisHost + ":" + redisPort)
+				.setConnectionPoolSize(50)          // 커넥션 풀 최대 크기
+				.setConnectionMinimumIdleSize(10)   // 최소 유휴 커넥션 수
+				.setRetryAttempts(3)                // 재시도 횟수
+				.setRetryInterval(1500)             // 재시도 간격 (ms)
+				.setTimeout(3000)                   // 명령 실행 타임아웃 (ms)
+				.setConnectTimeout(10000);          // 연결 타임아웃 (ms)
+
+		return Redisson.create(config);
+	}
+}

--- a/src/main/java/com/chaean/teamchatsa/global/exception/ErrorCode.java
+++ b/src/main/java/com/chaean/teamchatsa/global/exception/ErrorCode.java
@@ -10,6 +10,8 @@ public enum ErrorCode {
 
 	// 400
 	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력입니다."),
+	INVALID_STATE(HttpStatus.BAD_REQUEST, "잘못된 상태입니다."),
+	DUPLICATE_RESOURCE(HttpStatus.BAD_REQUEST, "이미 존재하는 자원입니다."),
 
 	// 401
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
@@ -26,6 +28,12 @@ public enum ErrorCode {
 	// 404
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
 	NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 자원을 찾을 수 없습니다."),
+	MATCH_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "매치 게시글을 찾을 수 없습니다."),
+	TEAM_NOT_FOUND(HttpStatus.NOT_FOUND, "팀을 찾을 수 없습니다."),
+	APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "매치 지원서를 찾을 수 없습니다."),
+
+	// 409
+	LOCK_ACQUISITION_FAILED(HttpStatus.CONFLICT, "다른 요청이 처리 중입니다. 잠시 후 다시 시도해주세요."),
 
 	// 500
 	INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");

--- a/src/main/resources/db/migration/V1__init_schema.sql
+++ b/src/main/resources/db/migration/V1__init_schema.sql
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS "team" (
     contact_type VARCHAR(30) NOT NULL ,
     CONSTRAINT team_contact_type_check CHECK (contact_type IN ('EMAIL','PHONE', 'KAKAO')),
     contact VARCHAR(50) NOT NULL,
+    level VARCHAR(20) NOT NULL,
     img TEXT NULL,
     is_deleted BOOLEAN NOT NULL DEFAULT false,
     created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
@@ -63,6 +64,7 @@ CREATE TABLE IF NOT EXISTS "match_post"
     match_date TIMESTAMP NOT NULL,
     lat DOUBLE PRECISION NOT NULL,
     lng DOUBLE PRECISION NOT NULL,
+    address VARCHAR(255) NOT NULL,
     place_name VARCHAR(120),
 
     -- 편의용

--- a/src/main/resources/db/migration/V3__create_unique.sql
+++ b/src/main/resources/db/migration/V3__create_unique.sql
@@ -4,3 +4,6 @@ ALTER TABLE "team"
 ALTER TABLE "team_member"
     ADD CONSTRAINT unique_team_user UNIQUE (user_id) DEFERRABLE INITIALLY IMMEDIATE,
     ADD CONSTRAINT unique_team_team_user UNIQUE (team_id, user_id) DEFERRABLE INITIALLY IMMEDIATE;
+
+ALTER TABLE "match_application"
+    ADD CONSTRAINT unique_match_post_team UNIQUE (post_id, applicant_team_id) DEFERRABLE INITIALLY IMMEDIATE;

--- a/src/test/java/com/chaean/teamchatsa/domain/team/service/TeamServiceTest.java
+++ b/src/test/java/com/chaean/teamchatsa/domain/team/service/TeamServiceTest.java
@@ -17,10 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.*;
 
 import java.util.Collections;
 import java.util.Optional;
@@ -108,12 +105,14 @@ class TeamServiceTest {
         @DisplayName("성공")
         void success() {
             // given
-            Pageable pageable = PageRequest.of(0, 10);
+            int page = 0;
+            int size = 10;
+            Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
             Slice<TeamListRes> expected = new SliceImpl<>(Collections.emptyList());
-            given(teamRepo.findTeamListSlice(pageable)).willReturn(expected);
+            given(teamRepo.findTeamListWithPagination(pageable)).willReturn(expected);
 
             // when
-            Slice<TeamListRes> result = teamService.findTeamList(pageable);
+            Slice<TeamListRes> result = teamService.findTeamList(page, size);
 
             // then
             assertThat(result).isEqualTo(expected);


### PR DESCRIPTION
  ## 1. 주요 기능
  - **매치 게시글**: 작성, 삭제, 목록/상세 조회 (Slice 페이지네이션)
  - **매치 신청**: 신청, 취소, 수락, 거절
  - **동시성 제어**: Redisson 분산 락 + DB Unique Constraint
  - **권한 검증**: @RequireTeamRole 단순화 및 모든 CUD 작업에 적용

  ##  2. 추가된 스택
  - **Redisson 3.52.0**: 분산 락 구현
  - **QueryDSL JPA 7.0**: N+1 문제 해결 및 타입 안전 쿼리
  - **Spring AOP**: 선언적 권한 검증 및 분산 락

  ## 📊 API 엔드포인트
  | Method | Endpoint | 권한 | 설명 |
  |--------|----------|------|------|
  | POST | `/api/v1/matches` | LEADER, CO_LEADER | 매치 작성 |
  | DELETE | `/api/v1/matches/{matchId}` | LEADER, CO_LEADER | 매치 삭제 |
  | GET | `/api/v1/matches` | - | 목록 조회 |
  | GET | `/api/v1/matches/{matchId}` | - | 상세 조회 |
  | POST | `/api/v1/matches/{matchId}/apply` | LEADER, CO_LEADER | 신청 |
  | POST | `/api/v1/matches/{matchId}/cancel` | LEADER, CO_LEADER | 취소 |
  | POST | `/api/v1/matches/{matchId}/accept/{applicantId}` | LEADER, CO_LEADER | 수락 |
  | POST | `/api/v1/matches/{matchId}/reject/{applicantId}` | LEADER, CO_LEADER | 거절  |